### PR TITLE
Strongly typed vecs

### DIFF
--- a/src/joymath.h
+++ b/src/joymath.h
@@ -5,12 +5,74 @@
 #include <numeric>
 
 namespace joytracer {
+    /*
+    * Non normalized vector.
+    */
+    class Vec3 {
+    protected:
+        std::array<double, 3> m_value;
+    public:
+        constexpr Vec3(const std::array<double, 3> &vector): m_value(vector) {
+
+        }
+
+        const std::array<double, 3>& get_value() const {
+            return m_value;
+        }
+
+        constexpr Vec3 operator+(const Vec3 &other) const {
+            return this->m_value + other.m_value;
+        }
+
+        constexpr Vec3 operator-(const Vec3 &other) const {
+            return this->m_value - other.m_value;
+        }
+
+        constexpr Vec3 operator*(double scalar) const {
+            return this->m_value * scalar;
+        }
+
+        constexpr Vec3 operator*(const Vec3 &other) const {
+            return this->m_value * other.m_value;
+        }
+
+        constexpr Vec3 operator/(double scalar) const {
+            return this->m_value / scalar;
+        }
+    };
+
+    /*
+    * A normalized vector.
+    */
+    class Normal3: public Vec3 {
+    public:
+        constexpr explicit Normal3(const Vec3 &vector):
+            Vec3(normalize(vector.get_value()))
+        {
+
+        }
+
+        constexpr Normal3 to_orthogonal() const {
+            return Normal3(
+                m_value[1] - m_value[2],
+                -m_value[0] + m_value[2],
+                m_value[0] - m_value[1]
+            );
+        }
+    private:
+        constexpr Normal3(double x, double y, double z): Vec3({x,y,z}) { }
+    };
+
     const double epsilon = 0.000000001;
 
     template<class T, std::size_t N>
     constexpr T dot(const std::array<T, N> &a,
         const std::array<T, N> &b) {
         return std::inner_product(a.begin(), a.end(), b.begin(), T(0));
+    }
+
+    constexpr double dot(const Vec3 &a, const Vec3 &b) {
+        return dot(a.get_value(), b.get_value());
     }
 
     template<class T>
@@ -21,6 +83,10 @@ namespace joytracer {
             a[2]*b[0] - a[0]*b[2],
             a[0]*b[1] - a[1]*b[0]
         };
+    }
+
+    constexpr Vec3 cross(const Vec3 &a, const Vec3 &b) {
+        return cross(a.get_value(), b.get_value());
     }
 
     template<class T, std::size_t N>
@@ -88,22 +154,14 @@ namespace joytracer {
         return result;
     }
 
-    constexpr std::array<double, 3> normal_to_orthogonal(const std::array<double, 3> normal) {
-        return std::array{
-            normal[1] - normal[2],
-            -normal[0] + normal[2],
-            normal[0] - normal[1]
-        };
-    }
-
     constexpr std::array<std::array<double, 3>, 3> normal_to_orthonormal_matrix(
-        const std::array<double, 3> &first_normal,
-        const std::array<double, 3> &second_normal) {
-        auto third_normal = normalize(cross(first_normal, second_normal));
+        const Normal3 &first_normal,
+        const Normal3 &second_normal) {
+        auto third_normal = Normal3(cross(first_normal, second_normal));
         return std::array{
-            first_normal,
-            cross(third_normal, first_normal),
-            third_normal
+            first_normal.get_value(),
+            cross(third_normal, first_normal).get_value(),
+            third_normal.get_value()
         };
     }
 
@@ -122,5 +180,15 @@ namespace joytracer {
         });
 
         return result;
+    }
+
+    constexpr Vec3 dot(const Vec3 &vec, const std::array<std::array<double, 3>, 3> &matrix) {
+        return dot(vec.get_value(), matrix);
+    }
+
+    // TODO: Fix this wrapper signature ASAP. I am no mathematician, but my OOP sense
+    // tells me that result is normal if matrix is an orthonormal projection.
+    constexpr Normal3 dot(const Normal3 &vec, const std::array<std::array<double, 3>, 3> &matrix) {
+        return Normal3(dot(vec.get_value(), matrix));
     }
 }

--- a/src/joymath.h
+++ b/src/joymath.h
@@ -201,4 +201,53 @@ namespace joytracer {
             third_normal.get_value()
         };
     }
+
+    /*
+    * Type for a color.
+    */
+    class Color {
+    private:
+        std::array<double, 3> m_value;
+        constexpr Color(const std::array<double, 3> &rgb) :
+            m_value(rgb) {}
+    public:
+        constexpr Color(): m_value() {}
+        std::array<double, 3> to_rgb() { return m_value; }
+
+        static constexpr Color from_rgb(const std::array<double, 3> &rgb) {
+            return Color(rgb);
+        }
+
+        static constexpr Color black() { return Color(std::array{0.0, 0.0, 0.0}); }
+        static constexpr Color white() { return Color(std::array{1.0, 1.0, 1.0}); }
+
+        static Color blend(
+            const std::vector<Color> &colors
+        );
+        static constexpr Color weighted_blend(
+            const Color &first_color, const Color &second_color,
+            const double first_weight, const double second_weight
+        );
+        static constexpr Color substractive_mix(
+            const Color &first_color, const Color &second_color
+        );
+    };
+
+    constexpr Color Color::weighted_blend(
+        const Color &first_color, const Color &second_color,
+        const double first_weight, const double second_weight
+    ) {
+        return from_rgb((
+            first_color.m_value * first_weight +
+            second_color.m_value * second_weight
+        ) / (first_weight + second_weight));
+    }
+
+    constexpr Color Color::substractive_mix(
+        const Color &first_color, const Color &second_color
+    ) {
+        return from_rgb(
+            first_color.m_value * second_color.m_value
+        );
+    }
 }

--- a/src/joymath.h
+++ b/src/joymath.h
@@ -5,74 +5,12 @@
 #include <numeric>
 
 namespace joytracer {
-    /*
-    * Non normalized vector.
-    */
-    class Vec3 {
-    protected:
-        std::array<double, 3> m_value;
-    public:
-        constexpr Vec3(const std::array<double, 3> &vector): m_value(vector) {
-
-        }
-
-        const std::array<double, 3>& get_value() const {
-            return m_value;
-        }
-
-        constexpr Vec3 operator+(const Vec3 &other) const {
-            return this->m_value + other.m_value;
-        }
-
-        constexpr Vec3 operator-(const Vec3 &other) const {
-            return this->m_value - other.m_value;
-        }
-
-        constexpr Vec3 operator*(double scalar) const {
-            return this->m_value * scalar;
-        }
-
-        constexpr Vec3 operator*(const Vec3 &other) const {
-            return this->m_value * other.m_value;
-        }
-
-        constexpr Vec3 operator/(double scalar) const {
-            return this->m_value / scalar;
-        }
-    };
-
-    /*
-    * A normalized vector.
-    */
-    class Normal3: public Vec3 {
-    public:
-        constexpr explicit Normal3(const Vec3 &vector):
-            Vec3(normalize(vector.get_value()))
-        {
-
-        }
-
-        constexpr Normal3 to_orthogonal() const {
-            return Normal3(
-                m_value[1] - m_value[2],
-                -m_value[0] + m_value[2],
-                m_value[0] - m_value[1]
-            );
-        }
-    private:
-        constexpr Normal3(double x, double y, double z): Vec3({x,y,z}) { }
-    };
-
     const double epsilon = 0.000000001;
 
     template<class T, std::size_t N>
     constexpr T dot(const std::array<T, N> &a,
         const std::array<T, N> &b) {
         return std::inner_product(a.begin(), a.end(), b.begin(), T(0));
-    }
-
-    constexpr double dot(const Vec3 &a, const Vec3 &b) {
-        return dot(a.get_value(), b.get_value());
     }
 
     template<class T>
@@ -83,10 +21,6 @@ namespace joytracer {
             a[2]*b[0] - a[0]*b[2],
             a[0]*b[1] - a[1]*b[0]
         };
-    }
-
-    constexpr Vec3 cross(const Vec3 &a, const Vec3 &b) {
-        return cross(a.get_value(), b.get_value());
     }
 
     template<class T, std::size_t N>
@@ -154,17 +88,6 @@ namespace joytracer {
         return result;
     }
 
-    constexpr std::array<std::array<double, 3>, 3> normal_to_orthonormal_matrix(
-        const Normal3 &first_normal,
-        const Normal3 &second_normal) {
-        auto third_normal = Normal3(cross(first_normal, second_normal));
-        return std::array{
-            first_normal.get_value(),
-            cross(third_normal, first_normal).get_value(),
-            third_normal.get_value()
-        };
-    }
-
     template<class T>
     constexpr std::array<T, 3> dot(const std::array<T, 3> &vec,
         const std::array<std::array<T, 3>, 3> &matrix) {
@@ -182,13 +105,100 @@ namespace joytracer {
         return result;
     }
 
+    /*
+    * Non normalized vector.
+    */
+    class Vec3 {
+    protected:
+        std::array<double, 3> m_value;
+    public:
+        constexpr Vec3(): m_value() {}
+
+        constexpr Vec3(const std::array<double, 3> &vector): m_value(vector) {
+
+        }
+
+        constexpr double operator[](size_t i) {
+            return m_value[i];
+        }
+
+        constexpr const std::array<double, 3>& get_value() const {
+            return m_value;
+        }
+
+        constexpr Vec3 operator+(const Vec3 &other) const {
+            return this->m_value + other.m_value;
+        }
+
+        constexpr Vec3 operator-(const Vec3 &other) const {
+            return this->m_value - other.m_value;
+        }
+
+        constexpr Vec3 operator*(double scalar) const {
+            return this->m_value * scalar;
+        }
+
+        constexpr Vec3 operator*(const Vec3 &other) const {
+            return this->m_value * other.m_value;
+        }
+
+        constexpr Vec3 operator/(double scalar) const {
+            return this->m_value / scalar;
+        }
+
+        constexpr auto vector_length() const {
+            return joytracer::vector_length(m_value);
+        }
+    };
+
+    /*
+    * A normalized vector.
+    */
+    class Normal3: public Vec3 {
+    public:
+        constexpr explicit Normal3(const Vec3 &vector):
+            Vec3(normalize(vector.get_value()))
+        {
+
+        }
+
+        constexpr Normal3 to_orthogonal() const {
+            return Normal3(
+                m_value[1] - m_value[2],
+                -m_value[0] + m_value[2],
+                m_value[0] - m_value[1]
+            );
+        }
+    private:
+        constexpr Normal3(double x, double y, double z): Vec3({x,y,z}) { }
+    };
+
+    constexpr double dot(const Vec3 &a, const Vec3 &b) {
+        return dot(a.get_value(), b.get_value());
+    }
+
     constexpr Vec3 dot(const Vec3 &vec, const std::array<std::array<double, 3>, 3> &matrix) {
         return dot(vec.get_value(), matrix);
+    }
+
+    constexpr Vec3 cross(const Vec3 &a, const Vec3 &b) {
+        return cross(a.get_value(), b.get_value());
     }
 
     // TODO: Fix this wrapper signature ASAP. I am no mathematician, but my OOP sense
     // tells me that result is normal if matrix is an orthonormal projection.
     constexpr Normal3 dot(const Normal3 &vec, const std::array<std::array<double, 3>, 3> &matrix) {
         return Normal3(dot(vec.get_value(), matrix));
+    }
+
+    constexpr std::array<std::array<double, 3>, 3> normal_to_orthonormal_matrix(
+        const Normal3 &first_normal,
+        const Normal3 &second_normal) {
+        auto third_normal = Normal3(cross(first_normal, second_normal));
+        return std::array{
+            first_normal.get_value(),
+            cross(third_normal, first_normal).get_value(),
+            third_normal.get_value()
+        };
     }
 }

--- a/src/joytracer.cpp
+++ b/src/joytracer.cpp
@@ -6,34 +6,9 @@
 #include "joytracer.h"
 
 namespace joytracer {
-    class RandomHammersleyPoint {
-        private:
-            std::vector<std::array<double, 3>> m_points;
-            std::random_device m_random_device;
-            std::mt19937 m_random_engine;
-            std::uniform_int_distribution<int> m_random_distribution;
-        public:
-            RandomHammersleyPoint(int max_points) :
-                m_points(max_points),
-                m_random_device(),
-                m_random_engine(m_random_device()),
-                m_random_distribution(0, max_points - 1) {
-                std::vector<int> range(max_points);
-                std::iota(range.begin(), range.end(), 0);
-                std::transform(range.begin(), range.end(), m_points.begin(), [&](auto &i) -> auto{
-                    auto uv = hammersley::hammersley2d(i, max_points);
-                    return hammersley::hemispheresample_uniform(uv[0], uv[1]);
-                });
-            }
-
-            std::array<double, 3> operator()() {
-                return m_points.at(m_random_distribution(m_random_engine));
-            }
-    };
-
     std::optional<HitPoint> project_ray_on_plane_frontface(
         const Ray &ray,
-        const std::array<double, 3> &plane_origin,
+        const vec3 &plane_origin,
         const std::array<double, 3> &plane_normal) {
         // Calculate if it may hit
         auto denom = dot(ray.get_normal(), plane_normal);
@@ -55,7 +30,7 @@ namespace joytracer {
     }
 
     Triangle::Triangle(
-            const std::array<std::array<double, 3>, 3> &vertices,
+            const std::array<vec3, 3> &vertices,
             const std::array<double, 3> &color
         ) : m_vertices(vertices), m_color(color),
             m_normal(normalize(cross(
@@ -168,11 +143,10 @@ namespace joytracer {
         ), reflect - 1));
     }
 
-    RandomHammersleyPoint random_hemisphere_point(1000);
-    std::vector<std::array<double, 3>> hemisphere_points = ([]() -> auto {
+    std::vector<vec3> hemisphere_points = ([]() -> auto {
         const uint32_t point_count = 100;
         std::vector<uint32_t> range(point_count);
-        std::vector<std::array<double, 3>> points(point_count);
+        std::vector<vec3> points(point_count);
         std:iota(range.begin(), range.end(), 0);
         std::transform(range.begin(), range.end(), points.begin(), [=](uint32_t i){
             auto uv = hammersley::hammersley2d(i, point_count);

--- a/src/joytracer.cpp
+++ b/src/joytracer.cpp
@@ -2,7 +2,6 @@
 #include <random>
 
 #include "hammersley.h"
-#include "joymath.h"
 #include "joytracer.h"
 
 namespace joytracer {
@@ -60,7 +59,7 @@ namespace joytracer {
     }
 
     std::optional<HitResult> Floor::hit_test(const Ray &ray) const {
-        auto projection = project_ray_on_plane_frontface(ray, Vec3({0.0, 0.0, 0.0}), Vec3({0.0, 0.0, 1.0}));
+        auto projection = project_ray_on_plane_frontface(ray, Vec3({0.0, 0.0, 0.0}), Normal3(Vec3({0.0, 0.0, 1.0})));
 
         if (!projection) {
             return std::nullopt;
@@ -78,7 +77,7 @@ namespace joytracer {
 
     std::optional<HitResult> Sphere::hit_test(const Ray &ray) const {
         auto origin_to_center = ray.get_origin() - m_center;
-        auto origin_to_center_length = vector_length(origin_to_center);
+        auto origin_to_center_length = origin_to_center.vector_length();
         auto projection = dot(ray.get_normal(), origin_to_center);
         auto square = projection * projection -
         origin_to_center_length * origin_to_center_length +
@@ -102,7 +101,7 @@ namespace joytracer {
         return HitResult(
             distance,
             hit_point,
-            normalize(hit_point - m_center),
+            Normal3(hit_point - m_center),
             m_color);
     }
 
@@ -151,7 +150,7 @@ namespace joytracer {
         std:iota(range.begin(), range.end(), 0);
         std::transform(range.begin(), range.end(), points.begin(), [=](uint32_t i){
             auto uv = hammersley::hammersley2d(i, point_count);
-            return hammersley::hemispheresample_uniform(uv[0], uv[1]);
+            return Vec3(hammersley::hemispheresample_uniform(uv[0], uv[1]));
         });
         return points;
     })();
@@ -192,7 +191,7 @@ namespace joytracer {
             [&](const auto &accum, const auto &hemisphere_point) -> auto {
                 return accum + trace_and_bounce_ray(Ray(
                     nearest_hit->point(),
-                    dot(hemisphere_point, orthonormal_matrix)
+                    Normal3(dot(hemisphere_point, orthonormal_matrix))
                 ), 1);
         }) / static_cast<double>(hemisphere_points.size());
 

--- a/src/joytracer.cpp
+++ b/src/joytracer.cpp
@@ -8,7 +8,7 @@
 namespace joytracer {
     std::optional<HitPoint> project_ray_on_plane_frontface(
         const Ray &ray,
-        const vec3 &plane_origin,
+        const Vec3 &plane_origin,
         const std::array<double, 3> &plane_normal) {
         // Calculate if it may hit
         auto denom = dot(ray.get_normal(), plane_normal);
@@ -30,7 +30,7 @@ namespace joytracer {
     }
 
     Triangle::Triangle(
-            const std::array<vec3, 3> &vertices,
+            const std::array<Vec3, 3> &vertices,
             const std::array<double, 3> &color
         ) : m_vertices(vertices), m_color(color),
             m_normal(normalize(cross(
@@ -143,10 +143,10 @@ namespace joytracer {
         ), reflect - 1));
     }
 
-    std::vector<vec3> hemisphere_points = ([]() -> auto {
+    std::vector<Vec3> hemisphere_points = ([]() -> auto {
         const uint32_t point_count = 100;
         std::vector<uint32_t> range(point_count);
-        std::vector<vec3> points(point_count);
+        std::vector<Vec3> points(point_count);
         std:iota(range.begin(), range.end(), 0);
         std::transform(range.begin(), range.end(), points.begin(), [=](uint32_t i){
             auto uv = hammersley::hammersley2d(i, point_count);

--- a/src/joytracer.h
+++ b/src/joytracer.h
@@ -9,19 +9,24 @@
 */
 namespace joytracer {
     /*
+    * Non normalized vector.
+    */
+    typedef std::array<double, 3> vec3;
+
+    /*
     * A ray cast out into the scene.
     */
     class Ray {
     private:
-        std::array<double, 3> m_origin;
+        vec3 m_origin;
         std::array<double, 3> m_normal;
     public:
-        Ray(const std::array<double, 3> &origin,
+        Ray(const vec3 &origin,
         const std::array<double, 3> &normal) :
         m_origin(origin),
         m_normal(normal) {}
 
-        const std::array<double, 3> &get_origin() const {
+        const vec3 &get_origin() const {
             return m_origin;
         }
 
@@ -36,18 +41,18 @@ namespace joytracer {
     class HitPoint {
     private:
         double m_distance;
-        std::array<double, 3> m_point;
+        vec3 m_point;
     public:
         HitPoint(
             double distance,
-            const std::array<double, 3> &point
+            const vec3 &point
         ) : m_distance(distance), m_point(point) {}
 
         double distance() const {
             return m_distance;
         }
 
-        const std::array<double, 3> &point() const {
+        const vec3 &point() const {
             return m_point;
         }
     };
@@ -58,13 +63,13 @@ namespace joytracer {
     class HitResult {
     private:
         double m_distance;
-        std::array<double, 3> m_point;
+        vec3 m_point;
         std::array<double, 3> m_normal;
         std::array<double, 3> m_color;
     public:
         HitResult(
             double distance,
-            const std::array<double, 3> &point,
+            vec3 &point,
             const std::array<double, 3> &normal,
             const std::array<double, 3> &color
         ) : m_distance(distance), m_point(point), m_normal(normal), m_color(color) {}
@@ -73,7 +78,7 @@ namespace joytracer {
             return m_distance;
         }
 
-        const std::array<double, 3> &point() const {
+        const vec3 &point() const {
             return m_point;
         }
 
@@ -100,12 +105,12 @@ namespace joytracer {
     */
     class Triangle : public Surface {
     private:
-        std::array<std::array<double, 3>, 3> m_vertices;
+        std::array<vec3, 3> m_vertices;
         std::array<double, 3> m_color;
         std::array<double, 3> m_normal;
     public:
         Triangle(
-            const std::array<std::array<double, 3>, 3> &vertices,
+            const std::array<vec3, 3> &vertices,
             const std::array<double, 3> &color
         );
         std::optional<HitResult> hit_test(const Ray &ray) const override;
@@ -127,10 +132,10 @@ namespace joytracer {
     class Sphere : public Surface {
     private:
         double m_radius;
-        std::array<double, 3> m_center;
+        vec3 m_center;
         std::array<double, 3> m_color;
     public:
-        Sphere(double radius, std::array<double, 3> center, std::array<double, 3> color) :
+        Sphere(double radius, vec3 center, std::array<double, 3> color) :
             m_radius(radius),
             m_center(center),
             m_color(color)
@@ -167,7 +172,7 @@ namespace joytracer {
     */
     class Camera {
     private:
-        std::array<double, 3> m_position;
+        vec3 m_position;
         std::array<double, 3> m_orientation;
         std::array<std::array<double, 3>, 3> m_view_transform;
         double m_focal_distance;

--- a/src/joytracer.h
+++ b/src/joytracer.h
@@ -9,16 +9,6 @@
 */
 namespace joytracer {
     /*
-    * Non normalized vector.
-    */
-    typedef std::array<double, 3> Vec3;
-
-    /*
-    * A normalized vector.
-    */
-    typedef std::array<double, 3> Normal3;
-
-    /*
     * A ray cast out into the scene.
     */
     class Ray {

--- a/src/joytracer.h
+++ b/src/joytracer.h
@@ -4,6 +4,8 @@
 #include <optional>
 #include <memory>
 
+#include "joymath.h"
+
 /*
 * Main namespace for the app.
 */

--- a/src/joytracer.h
+++ b/src/joytracer.h
@@ -11,26 +11,31 @@ namespace joytracer {
     /*
     * Non normalized vector.
     */
-    typedef std::array<double, 3> vec3;
+    typedef std::array<double, 3> Vec3;
+
+    /*
+    * A normalized vector.
+    */
+    typedef std::array<double, 3> Normal3;
 
     /*
     * A ray cast out into the scene.
     */
     class Ray {
     private:
-        vec3 m_origin;
-        std::array<double, 3> m_normal;
+        Vec3 m_origin;
+        Normal3 m_normal;
     public:
-        Ray(const vec3 &origin,
-        const std::array<double, 3> &normal) :
+        Ray(const Vec3 &origin,
+        const Normal3 &normal) :
         m_origin(origin),
         m_normal(normal) {}
 
-        const vec3 &get_origin() const {
+        const Vec3 &get_origin() const {
             return m_origin;
         }
 
-        const std::array<double, 3> &get_normal() const {
+        const Normal3 &get_normal() const {
             return m_normal;
         }
     };
@@ -41,18 +46,18 @@ namespace joytracer {
     class HitPoint {
     private:
         double m_distance;
-        vec3 m_point;
+        Vec3 m_point;
     public:
         HitPoint(
             double distance,
-            const vec3 &point
+            const Vec3 &point
         ) : m_distance(distance), m_point(point) {}
 
         double distance() const {
             return m_distance;
         }
 
-        const vec3 &point() const {
+        const Vec3 &point() const {
             return m_point;
         }
     };
@@ -63,14 +68,14 @@ namespace joytracer {
     class HitResult {
     private:
         double m_distance;
-        vec3 m_point;
-        std::array<double, 3> m_normal;
+        Vec3 m_point;
+        Normal3 m_normal;
         std::array<double, 3> m_color;
     public:
         HitResult(
             double distance,
-            vec3 &point,
-            const std::array<double, 3> &normal,
+            const Vec3 &point,
+            const Normal3 &normal,
             const std::array<double, 3> &color
         ) : m_distance(distance), m_point(point), m_normal(normal), m_color(color) {}
 
@@ -78,11 +83,11 @@ namespace joytracer {
             return m_distance;
         }
 
-        const vec3 &point() const {
+        const Vec3 &point() const {
             return m_point;
         }
 
-        const std::array<double, 3> &normal() const {
+        const Normal3 &normal() const {
             return m_normal;
         }
 
@@ -105,12 +110,12 @@ namespace joytracer {
     */
     class Triangle : public Surface {
     private:
-        std::array<vec3, 3> m_vertices;
+        std::array<Vec3, 3> m_vertices;
         std::array<double, 3> m_color;
-        std::array<double, 3> m_normal;
+        Normal3 m_normal;
     public:
         Triangle(
-            const std::array<vec3, 3> &vertices,
+            const std::array<Vec3, 3> &vertices,
             const std::array<double, 3> &color
         );
         std::optional<HitResult> hit_test(const Ray &ray) const override;
@@ -132,10 +137,10 @@ namespace joytracer {
     class Sphere : public Surface {
     private:
         double m_radius;
-        vec3 m_center;
+        Vec3 m_center;
         std::array<double, 3> m_color;
     public:
-        Sphere(double radius, vec3 center, std::array<double, 3> color) :
+        Sphere(double radius, Vec3 center, std::array<double, 3> color) :
             m_radius(radius),
             m_center(center),
             m_color(color)
@@ -151,7 +156,7 @@ namespace joytracer {
     private:
         std::vector<std::unique_ptr<Surface>> m_surfaces;
         std::array<double, 3> m_sky_color;
-        std::array<double, 3> m_sunlight_normal;
+        Normal3 m_sunlight_normal;
 
         std::optional<HitResult> trace_single_ray(const Ray &ray) const;
         std::array<double, 3> trace_and_bounce_ray(const Ray &ray, int reflect) const;
@@ -159,7 +164,7 @@ namespace joytracer {
         Scene(
             std::vector<std::unique_ptr<Surface>> surfaces,
             const std::array<double, 3> &sky_color,
-            const std::array<double, 3> &sunlight_normal
+            const Normal3 &sunlight_normal
         ) : m_surfaces(std::move(surfaces)),
         m_sky_color(sky_color),
         m_sunlight_normal(sunlight_normal) {}
@@ -172,13 +177,13 @@ namespace joytracer {
     */
     class Camera {
     private:
-        vec3 m_position;
+        Vec3 m_position;
         std::array<double, 3> m_orientation;
         std::array<std::array<double, 3>, 3> m_view_transform;
         double m_focal_distance;
         double m_plane_width, m_plane_height;
     public:
-        void set_position(const std::array<double, 3> &position) {
+        void set_position(const Vec3 &position) {
             m_position = position;
         }
 

--- a/src/joytracer.h
+++ b/src/joytracer.h
@@ -62,13 +62,13 @@ namespace joytracer {
         double m_distance;
         Vec3 m_point;
         Normal3 m_normal;
-        std::array<double, 3> m_color;
+        Color m_color;
     public:
         HitResult(
             double distance,
             const Vec3 &point,
             const Normal3 &normal,
-            const std::array<double, 3> &color
+            const Color &color
         ) : m_distance(distance), m_point(point), m_normal(normal), m_color(color) {}
 
         double distance() const {
@@ -83,7 +83,7 @@ namespace joytracer {
             return m_normal;
         }
 
-        const std::array<double, 3> &color() const {
+        const Color &color() const {
             return m_color;
         }
     };
@@ -103,12 +103,12 @@ namespace joytracer {
     class Triangle : public Surface {
     private:
         std::array<Vec3, 3> m_vertices;
-        std::array<double, 3> m_color;
+        Color m_color;
         Normal3 m_normal;
     public:
         Triangle(
             const std::array<Vec3, 3> &vertices,
-            const std::array<double, 3> &color
+            const Color &color
         );
         std::optional<HitResult> hit_test(const Ray &ray) const override;
     };
@@ -130,9 +130,9 @@ namespace joytracer {
     private:
         double m_radius;
         Vec3 m_center;
-        std::array<double, 3> m_color;
+        Color m_color;
     public:
-        Sphere(double radius, Vec3 center, std::array<double, 3> color) :
+        Sphere(double radius, Vec3 center, Color color) :
             m_radius(radius),
             m_center(center),
             m_color(color)
@@ -147,20 +147,20 @@ namespace joytracer {
     class Scene {
     private:
         std::vector<std::unique_ptr<Surface>> m_surfaces;
-        std::array<double, 3> m_sky_color;
+        Color m_sky_color;
         Normal3 m_sunlight_normal;
 
         std::optional<HitResult> trace_single_ray(const Ray &ray) const;
-        std::array<double, 3> trace_and_bounce_ray(const Ray &ray, int reflect) const;
+        Color trace_and_bounce_ray(const Ray &ray, int reflect) const;
     public:
         Scene(
             std::vector<std::unique_ptr<Surface>> surfaces,
-            const std::array<double, 3> &sky_color,
+            const Color &sky_color,
             const Normal3 &sunlight_normal
         ) : m_surfaces(std::move(surfaces)),
         m_sky_color(sky_color),
         m_sunlight_normal(sunlight_normal) {}
-        std::array<double, 3> trace_ray(const Ray &ray, int reflect) const;
+        Color trace_ray(const Ray &ray, int reflect) const;
     };
 
     /*
@@ -190,7 +190,7 @@ namespace joytracer {
             m_plane_width = width; m_plane_height = height;
         }
 
-        std::vector<std::array<double, 3>> render_scene(const Scene &scene, int width, int height);
-        std::array<double, 3> test_point(const Scene &scene, int width, int height, int x, int y);
+        std::vector<Color> render_scene(const Scene &scene, int width, int height);
+        Color test_point(const Scene &scene, int width, int height, int x, int y);
     };
 }

--- a/src/sdl_main.cpp
+++ b/src/sdl_main.cpp
@@ -37,11 +37,11 @@ int main(int argc, char** argv) {
 
         for (int y = 0; y < screen_height; ++y) {
             for (int x = 0; x < screen_width; ++x) {
-                int i = y * screen_width + x;
+                auto colorvalue = fixed_frame[y * screen_width + x].to_rgb();
                 backbuffer.set_pixel(x, y, 0xff000000 |
-                    (static_cast<uint32_t>(255 * fixed_frame[i][0])) |
-                    (static_cast<uint32_t>(255 * fixed_frame[i][1])) << 8 |
-                    (static_cast<uint32_t>(255 * fixed_frame[i][2])) << 16);
+                    (static_cast<uint32_t>(255 * colorvalue[0])) |
+                    (static_cast<uint32_t>(255 * colorvalue[1])) << 8 |
+                    (static_cast<uint32_t>(255 * colorvalue[2])) << 16);
             }
         }
     }
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
         },
         // onclick
         [&](int x, int y) -> void {
-            auto color = fixed_camera.test_point(test_scene, screen_width, screen_height, x, y);
+            auto color = fixed_camera.test_point(test_scene, screen_width, screen_height, x, y).to_rgb();
             std::cout
                 << "Color of (" << x << "," << y << "): "
                 << color[0] << ", " << color[1] << ", " << color[2] << ", " << '\n';

--- a/src/sdl_main.cpp
+++ b/src/sdl_main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     joytracer::Camera fixed_camera{};
     fixed_camera.set_focal_distance(1.0);
     fixed_camera.set_plane_size(1.0, static_cast<double>(screen_height) / static_cast<double>(screen_width));
-    fixed_camera.set_position({0.0, 0.0, 1.77});
+    fixed_camera.set_position(joytracer::Vec3({0.0, 0.0, 1.77}));
     fixed_camera.set_orientation({0.0, std::acos(-1) * 0.50, 0.0});
     auto fixed_frame = fixed_camera.render_scene(test_scene, screen_width, screen_height);
 

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -52,7 +52,7 @@ namespace joytracer {
                 auto center = node.second.get("center", std::array{0.0, 0.0, 0.0}, Vec3Translator());
                 auto color = node.second.get("color", std::array{0.0, 0.0, 0.0}, Vec3Translator());
                 surfaces.push_back(std::make_unique<Sphere>(
-                    radius, center, color
+                    radius, center, Color::from_rgb(color)
                 ));
             }},
             {"sky-color", [&sky_color](const pt::ptree::value_type &node){
@@ -80,7 +80,7 @@ namespace joytracer {
                     if (handler != node_handlers.end()) handler->second(node);
                 }
 
-                surfaces.push_back(std::make_unique<Triangle>(vertices, color));
+                surfaces.push_back(std::make_unique<Triangle>(vertices, Color::from_rgb(color)));
             }},
         };
 
@@ -89,6 +89,6 @@ namespace joytracer {
             if (handler != node_handlers.end()) handler->second(node);
         }
 
-        return Scene(std::move(surfaces), sky_color, Normal3(sunlight_normal));
+        return Scene(std::move(surfaces), Color::from_rgb(sky_color), Normal3(sunlight_normal));
     }
 } // namespace joytracer

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -59,10 +59,10 @@ namespace joytracer {
                 sky_color = node.second.get_value(std::array{0.0, 0.0, 0.0}, Vec3Translator());
             }},
             {"sunlight-normal", [&sunlight_normal](const pt::ptree::value_type &node){
-                sunlight_normal = normalize(node.second.get_value(std::array{0.0, 0.0, 0.0}, Vec3Translator()));
+                sunlight_normal = node.second.get_value(std::array{0.0, 0.0, 0.0}, Vec3Translator());
             }},
             {"triangle", [&surfaces](const pt::ptree::value_type &node){
-                std::array<std::array<double, 3>, 3> vertices;
+                std::array<Vec3, 3> vertices;
                 std::array<double, 3> color;
                 auto vert_iterator = vertices.begin();
 
@@ -89,6 +89,6 @@ namespace joytracer {
             if (handler != node_handlers.end()) handler->second(node);
         }
 
-        return Scene(std::move(surfaces), sky_color, sunlight_normal);
+        return Scene(std::move(surfaces), sky_color, Normal3(sunlight_normal));
     }
 } // namespace joytracer


### PR DESCRIPTION
This branch declares vectors as `Vec3` instead of `std::array<double, 3>`, this may help in a future transition from custom math code to external packages. I also created the `Normal3` type to enforce passing normalized vectors where needed. There is also a new `Color` type, this is supposed to help changing color space on the fly at compile time. This first version is hard coded RGB, but future versions of it will have to implement `from_rgb` and `to_rgb` for helping developers work with a familiar color scheme and pass it around to SDL.

I also added some comments and TODOS here and there, I will open issues on the GitHub tracker from them.